### PR TITLE
chore: add Claude Code skills and project config

### DIFF
--- a/.agents/skills/js-deps/SKILL.md
+++ b/.agents/skills/js-deps/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: js-deps
+description: >
+  Maintain JavaScript/Node.js packages through security audits or dependency updates on a dedicated branch.
+  Supports npm, yarn, pnpm, and bun. Use for: security audits, CVE fixes, vulnerability checks,
+  dependency updates, package upgrades, or when user types "/js-deps" with or without specific package names or glob patterns. Use "help" or "--help" to show update options.
+license: MIT
+compatibility: Requires git, a JavaScript package manager (npm, yarn, pnpm, or bun), and network access to package registries
+metadata:
+  author: Gregory Murray
+  repository: github.com/whatifwedigdeeper/agent-skills
+  version: "0.4"
+---
+
+# JS Deps
+
+## Arguments
+
+Specific package names (e.g. `jest @types/jest`), `.` for all packages, or glob patterns (e.g. `@testing-library/*`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
+
+## Workflow Selection
+
+Based on user request:
+- **Security audit** (audit, CVE, vulnerabilities, security): Read [references/audit-workflow.md](references/audit-workflow.md)
+- **Dependency updates** (update, upgrade, latest, modernize): Read [references/update-workflow.md](references/update-workflow.md)
+
+## Shared Process
+
+### 1. Create Branch
+
+Stash uncommitted changes and create a dedicated branch:
+```bash
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+BRANCH_NAME="js-deps-$TIMESTAMP"
+git stash --include-untracked
+git checkout -b "$BRANCH_NAME"
+```
+
+### 2. Detect Package Manager
+
+Detect from lock files and `package.json` `packageManager` field (which takes precedence). See [references/package-managers.md](references/package-managers.md) for detection logic and command mappings.
+
+### 3. Verify Registry Access
+
+Verify the package manager CLI is available and, for npm, that it can reach the registry. See [references/package-managers.md](references/package-managers.md) for manager-specific verification commands.
+
+If verification fails, prompt user: "Cannot reach package registry. Sandbox may be blocking network access. To allow package manager commands in sandbox mode, update settings.json."
+
+Do not proceed until verification passes.
+
+### 4. Discover Package Locations
+
+Find all `package.json` files excluding `node_modules`. Store results as an array of directories to process.
+
+### 5. Install Dependencies
+
+Install dependencies in each discovered package directory so that `npm outdated` (and similar commands) can accurately compare installed versions against the registry. Without `node_modules`, exact-pinned packages (no `^` or `~`) won't appear in outdated reports.
+
+### 6. Identify Packages
+
+- Parse `$ARGUMENTS` to determine packages
+- For globs, expand against package.json dependencies
+- For `.`, process all packages
+
+### 7. Validate Changes
+
+Check `package.json` scripts for available validation commands. Run available scripts using `$PM run <script>` in order (build, lint, test), continuing on failure to collect all errors. Skip any that don't exist.
+
+If validation fails, revert the failing package to its previous version before continuing with remaining packages:
+```bash
+git checkout -- package.json package-lock.json  # or the equivalent lock file
+$PM install
+```
+
+### 8. Update Documentation for Major Version Changes
+
+For major version upgrades (e.g., 18.x to 19.x):
+
+1. Search for version references in markdown files
+2. Update in: `CLAUDE.md`, `README.md`, `docs/*.md`
+3. Include changes in report/PR description
+
+### 9. Cleanup
+
+If a PR was created, do not delete the branch — it's needed for the open PR.
+
+```bash
+git checkout -
+git stash list | grep -q . && git stash pop
+# Only delete branch if no PR was created
+if ! gh pr view "$BRANCH_NAME" --json url > /dev/null 2>&1; then
+  git branch -d "$BRANCH_NAME"
+fi
+```
+
+## Edge Cases
+
+- **Glob matches nothing**: Warn and list available packages
+- **Unsupported package manager**: Prompt user for guidance

--- a/.agents/skills/js-deps/references/audit-workflow.md
+++ b/.agents/skills/js-deps/references/audit-workflow.md
@@ -1,0 +1,126 @@
+# Security Audit Workflow
+
+Use the detected `$PM` package manager for all commands. See [package-managers.md](package-managers.md) for command mappings.
+
+## Audit Execution
+
+### Run Security Audit on Each Directory
+
+For each directory containing package.json:
+```bash
+cd <directory>
+$PM audit --json > audit-report-<dir-name>.json
+```
+
+Note: bun does not support audit. If using bun, skip audit and inform user.
+
+Collect all audit results into a consolidated report.
+
+### Categorize by Severity
+
+Parse audit results for each directory:
+
+| Severity | Action |
+|----------|--------|
+| Critical | Immediate action required |
+| High | Serious risk, patch ASAP |
+| Moderate | Should fix soon |
+| Low | Fix when convenient |
+
+### Determine Strategy
+
+Per directory:
+- **1-3 packages**: Update sequentially
+- **4+ packages**: Use parallel Task subagents (2 packages per agent)
+
+If multiple directories have vulnerabilities, process them in parallel using separate agents.
+
+### Update Packages
+
+For each vulnerable package in each directory, use the appropriate install command from [package-managers.md](package-managers.md):
+```bash
+cd <directory>
+$PM install <package>@latest  # npm
+$PM add <package>@latest      # yarn, pnpm, bun
+```
+
+Validate after each update using available scripts from package.json (see SKILL.md step 7 for build/lint/test order). Continue on failure to collect all errors. If validation fails, revert to previous version before continuing.
+
+### Post-Audit Scan
+
+For each directory:
+```bash
+cd <directory>
+$PM audit
+```
+
+Compare before/after vulnerability counts per directory.
+
+## Parallel Execution
+
+### Per-Directory Parallelization
+
+When multiple directories have vulnerabilities, launch separate Task subagents for each:
+
+```
+Task({
+  subagent_type: 'general-purpose',
+  prompt: 'Audit and fix vulnerabilities in <directory>...',
+  run_in_background: true
+})
+```
+
+### Per-Package Parallelization
+
+Within a directory with >3 vulnerable packages, split into groups:
+
+```
+Task({
+  subagent_type: 'general-purpose',
+  prompt: 'Update packages X, Y in <directory> with full validation...',
+  run_in_background: true
+})
+```
+
+Collect results from all agents before generating final report.
+
+## Handle Results
+
+### On Success
+
+1. Generate consolidated security report
+2. Create commit with security fixes
+3. Push branch to remote:
+   ```bash
+   git push -u origin "$BRANCH_NAME"
+   ```
+4. Create PR using gh CLI:
+   ```bash
+   gh pr create --title "fix: Security audit fixes" --body "$(cat <<'EOF'
+   ## Summary
+   - Vulnerabilities fixed: [count]
+   - Remaining vulnerabilities: [count with reasons]
+
+   ## Changes by Directory
+   [list directories and packages updated]
+
+   ## Validation Results
+   | Check | Status |
+   |-------|--------|
+   | Build | pass/fail |
+   | Lint | pass/fail |
+   | Tests | pass/fail |
+   | Security Audit | X remaining |
+
+   Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+5. Return the PR URL to the user
+
+### On Failure
+
+- Categorize by directory and package
+- Provide specific remediation steps for unfixable vulnerabilities
+- If partially successful, still create PR with remaining issues noted
+

--- a/.agents/skills/js-deps/references/options.md
+++ b/.agents/skills/js-deps/references/options.md
@@ -1,0 +1,48 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, arguments, workflows, process steps, and notes). Then present the questions below using `AskUserQuestion`. The second question depends on the answer to the first.
+
+## Question 1: Workflow type
+
+Use `multiSelect: false`.
+
+| Option | Description |
+|--------|-------------|
+| Update dependencies | Update packages to newer versions |
+| Security fixes only | Only fix packages with known vulnerabilities |
+
+## Question 2a: Update filters (if "Update dependencies" was selected)
+
+Use `multiSelect: true`. Only selected version types are included in the update.
+
+| Option | Description |
+|--------|-------------|
+| Major | Include major version upgrades (e.g. 2.x → 3.x) |
+| Minor | Include minor version updates (e.g. 2.1 → 2.2) |
+| Patch | Include patch-level updates (e.g. 2.1.3 → 2.1.4) |
+| Skip .0 patches (Recommended) | Skip x.y.0 releases and wait for x.y.1+ bugfix releases |
+
+## Question 2b: Severity filter (if "Security fixes only" was selected)
+
+Use `multiSelect: true`. Nothing selected by default means all severities are included.
+
+| Option | Description |
+|--------|-------------|
+| Critical | Only fix critical severity vulnerabilities |
+| High | Include high severity vulnerabilities |
+| Moderate | Include moderate severity vulnerabilities |
+| All vulnerabilities (Recommended) | Fix all reported vulnerabilities regardless of severity |
+
+## How to Apply
+
+**Update dependencies path:**
+- **Major selected**: Include packages where the new major version differs from the current major version.
+- **Minor selected**: Include packages where the new minor version differs (but major is the same).
+- **Patch selected**: Include packages where only the patch version differs.
+- **None selected**: If no version types are selected, default to including all (major, minor, and patch).
+- **Skip .0 patches**: If the latest version ends in `.0` (e.g. `2.1.0`), skip it and keep the current version.
+
+**Security fixes path:**
+- Run `$PM audit` to identify vulnerable packages.
+- Filter audit results by the selected severity levels before applying fixes.
+- Use `$PM audit fix` (npm) or manually update vulnerable packages to patched versions.

--- a/.agents/skills/js-deps/references/package-managers.md
+++ b/.agents/skills/js-deps/references/package-managers.md
@@ -1,0 +1,69 @@
+# Package Manager Reference
+
+## Detection
+
+Check for lock files in order of precedence:
+
+| Lock file | Package manager |
+|-----------|-----------------|
+| `bun.lockb` | bun |
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+
+Also check `package.json` for `packageManager` field:
+```json
+{
+  "packageManager": "pnpm@8.6.0"
+}
+```
+
+If no lock file exists, default to npm.
+
+## Command Reference
+
+Use `$PM` as the detected package manager throughout the workflow.
+
+### Verify CLI and Connectivity
+
+| Manager | Command | Verifies |
+|---------|---------|----------|
+| npm | `npm ping` | Registry connectivity |
+| yarn | `yarn info yarn version` | CLI + registry connectivity |
+| pnpm | `pnpm view pnpm version` | CLI + registry connectivity |
+| bun | `bun --version` | CLI only (no registry ping) |
+
+### Audit
+
+| Manager | Command | JSON output |
+|---------|---------|-------------|
+| npm | `npm audit` | `npm audit --json` |
+| yarn | `yarn audit` | `yarn audit --json` |
+| pnpm | `pnpm audit` | `pnpm audit --json` |
+| bun | Not supported | - |
+
+### View Package Info
+
+| Manager | Latest version | Dist tags |
+|---------|----------------|-----------|
+| npm | `npm view <pkg> version` | `npm view <pkg> dist-tags` |
+| yarn | `yarn info <pkg> version` | `yarn info <pkg> dist-tags` |
+| pnpm | `pnpm view <pkg> version` | `pnpm view <pkg> dist-tags` |
+| bun | `bunx npm-view <pkg> version` | - |
+
+### Install/Update Package
+
+| Manager | Install latest | Install specific |
+|---------|----------------|------------------|
+| npm | `npm install <pkg>@latest` | `npm install <pkg>@<version>` |
+| yarn | `yarn add <pkg>@latest` | `yarn add <pkg>@<version>` |
+| pnpm | `pnpm add <pkg>@latest` | `pnpm add <pkg>@<version>` |
+| bun | `bun add <pkg>@latest` | `bun add <pkg>@<version>` |
+
+### Run Scripts
+
+All package managers support `$PM run <script>` syntax:
+- `npm run build`
+- `yarn run build` (or just `yarn build`)
+- `pnpm run build`
+- `bun run build`

--- a/.agents/skills/js-deps/references/update-workflow.md
+++ b/.agents/skills/js-deps/references/update-workflow.md
@@ -1,0 +1,88 @@
+# Dependency Update Workflow
+
+Use the detected `$PM` package manager for all commands. See [package-managers.md](package-managers.md) for command mappings.
+
+## Version Checking and Updates
+
+### Check and Update Versions
+
+Use the appropriate commands for your package manager (see [package-managers.md](package-managers.md)):
+
+```bash
+# Check latest version (npm/pnpm)
+$PM view <package> version
+
+# Prefer LTS when available
+$PM view <package> dist-tags
+
+# Update packages
+$PM install <package>@latest  # npm
+$PM add <package>@latest      # yarn, pnpm, bun
+```
+
+### Run Security Audit
+
+After updating, check for new vulnerabilities:
+```bash
+$PM audit
+$PM audit fix  # npm only; others require manual fixes
+```
+
+Note: bun does not support audit. If using bun, skip this step.
+
+## Handle Results
+
+### On Success
+
+1. Create commit with version changes
+2. Push branch to remote:
+   ```bash
+   git push -u origin "$BRANCH_NAME"
+   ```
+3. Check for existing dependency update PRs:
+   ```bash
+   gh pr list --search "chore: Update dependencies" --state open
+   ```
+4. Create PR using gh CLI:
+   ```bash
+   gh pr create --title "chore: Update dependencies" --body "$(cat <<'EOF'
+   ## Summary
+   - Updated packages: [list major version changes]
+   - Breaking changes fixed: [list code modifications]
+
+   ## Validation Results
+   | Check | Status |
+   |-------|--------|
+   | Build | pass/fail |
+   | Lint | pass/fail |
+   | Tests | pass/fail |
+   | Security Audit | X vulnerabilities |
+
+   ## Files Changed
+   - [list modified package.json files]
+
+   Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+5. Return the PR URL to the user
+
+### On Failure
+
+- Categorize errors (build/lint/test/audit)
+- Provide specific remediation steps
+- Offer options: isolate problem, revert specific updates, or abandon
+- If partially successful, still create PR with failing checks noted
+
+## Error Categories
+
+| Category | Examples | Remediation |
+|----------|----------|-------------|
+| Build | Type errors, missing dependencies | Update @types/*, check changelogs |
+| Lint | Code style issues | Run `$PM run lint -- --fix` |
+| Test | Breaking API changes | Review migration guides |
+| Audit | Vulnerabilities | Manual remediation steps |
+
+## Cleanup Note
+
+After creating a PR, do not delete the branch - it's needed for the open PR.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: learn
+description: >-
+  Extracts lessons learned from conversations and persists them to AI assistant
+  config files (CLAUDE.md, GEMINI.md, AGENTS.md, Cursor, Copilot, Windsurf,
+  Continue).
+  Use when: debugging revealed issues, commands failed then succeeded, assumptions proved wrong, workarounds were discovered, undocumented behavior found,
+  or user says "/learn" or "remember this".
+license: MIT
+compatibility: Requires bash shell and file system write access
+metadata:
+  author: Gregory Murray
+  repository: github.com/whatifwedigdeeper/agent-skills
+  version: "0.5"
+---
+
+# Learn from Conversation
+
+Analyze the conversation to extract lessons learned, then persist them to AI assistant configuration files.
+
+## Arguments
+
+Optional text to narrow what to learn (e.g. `sandbox workaround`, `that build fix`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
+
+## Supported Assistants
+
+| Assistant | Config File | Format |
+|-----------|-------------|--------|
+| Claude Code | `CLAUDE.md` | Markdown |
+| Gemini | `GEMINI.md` | Markdown |
+| AGENTS.md | `AGENTS.md` | Markdown |
+| Cursor | `.cursorrules` or `.cursor/rules/*.mdc` | Markdown/MDC |
+| GitHub Copilot | `.github/copilot-instructions.md` | Markdown |
+| Windsurf | `.windsurf/rules/rules.md` | Markdown |
+| Continue | `.continuerc.json` | JSON |
+
+See [references/assistant-configs.md](references/assistant-configs.md) for format details.
+
+## Process
+
+### 1. Detect and Assess Configurations
+
+Scan for config files and check their sizes:
+
+```bash
+for f in CLAUDE.md GEMINI.md AGENTS.md .cursorrules .github/copilot-instructions.md \
+  .windsurf/rules/rules.md .continuerc.json; do
+  [ -f "$f" ] && wc -l "$f"
+done
+find .cursor/rules -name "*.mdc" -exec wc -l {} \; 2>/dev/null
+```
+
+**Behavior based on detection:**
+
+| Scenario | Action |
+|----------|--------|
+| Single config found | Update it automatically |
+| Multiple configs found | Prompt user to select which to update |
+| No configs found | Display init commands from [assistant-configs.md](references/assistant-configs.md), then exit |
+
+#### Size Thresholds
+
+| Lines | Status | Action |
+|-------|--------|--------|
+| < 400 | Healthy | Add learnings directly |
+| 400-500 | Warning | Add carefully, suggest cleanup |
+| > 500 | Oversized | [Refactor](references/refactoring.md) before adding new content |
+
+Use these same thresholds throughout (routing decisions, present-and-confirm, edge cases).
+
+#### Discover Existing Skills
+
+List skills for routing decisions:
+
+```bash
+find . -name "SKILL.md" -type f 2>/dev/null | grep -v node_modules | \
+  xargs grep -l "^name:" | while read -r f; do
+  grep -m1 "^name:" "$f" | sed 's/name: //'
+done
+```
+
+### 2. Analyze Conversation
+
+Scan for:
+- **Corrections**: Commands retried, assumptions proven wrong, missing prerequisites
+- **Discoveries**: Undocumented patterns, integration quirks, environment requirements
+- **Improvements**: Steps that should be automated or validated earlier
+- **Instruction Violations**: Existing config file guidelines that were not followed during the conversation. If the user had to remind the assistant to do something already documented, flag which section was ignored and assess whether the wording needs to be more prominent or actionable
+
+### 3. Categorize and Route Each Learning
+
+| Category | Primary Destination | Fallback When Oversized |
+|----------|---------------------|------------------------|
+| Project facts | Config file | Extract to new skill |
+| Prerequisites | Config file | Extract to `project-setup` skill |
+| Environment | Config file | Extract to `environment-setup` skill |
+| Workflow pattern | Existing related skill | Create new skill |
+| Automated workflow | New skill | New skill (always) |
+
+#### Routing Decision Tree
+
+For each learning, evaluate in order:
+
+1. **Is this a multi-step automated workflow (>5 steps)?**
+   - YES → Create new skill (proceed to Step 5, Route C)
+   - NO → Continue
+
+2. **Does an existing skill cover this topic?**
+   - YES → Update that skill
+   - NO → Continue
+
+3. **Is the target config file oversized (>500 lines)?**
+   - YES → Create new skill OR offer refactoring (see Step 4)
+   - NO → Continue
+
+4. **Is this learning situation-specific (applies to narrow context)?**
+   - YES → Create new skill with `globs` or context constraints
+   - NO → Add to config file
+
+#### Size-Based Rules
+
+| Learning Size | Preferred Destination |
+|---------------|----------------------|
+| < 3 lines | Config file (even if near threshold) |
+| 3-30 lines | Follow decision tree above |
+| > 30 lines | Strongly prefer skill creation |
+
+### 4. Present and Confirm
+
+For each learning, show:
+```
+**[Category]**: [Brief description]
+- Source: [What happened in conversation]
+- Proposed change: [Exact text or file to add]
+- Destination: [Config file] ([current] → [projected] lines)
+```
+
+#### Handle Size Threshold
+
+If adding the learning would push a config file over threshold:
+
+```
+Adding this learning would bring [filename] to [X] lines (threshold: [Y]).
+
+Options:
+1. Add learning anyway (not recommended)
+2. [Refactor](references/refactoring.md) existing content to skills first, then add
+3. Create a new skill for this learning instead
+4. Skip this config file
+```
+
+Ask for confirmation before applying each change.
+
+### 5. Apply Changes
+
+Apply changes based on routing decision from Step 3:
+
+#### Route A: Add to Config File
+
+**Markdown configs** (CLAUDE.md, GEMINI.md, AGENTS.md, Copilot, Windsurf):
+- Find appropriate section, preserve existing structure
+- Append to relevant section or create new section if needed
+
+**Cursor rules**:
+- Legacy `.cursorrules`: Treat like markdown, append content
+- Modern `.cursor/rules/*.mdc`: See [references/format-cursor-mdc.md](references/format-cursor-mdc.md)
+
+**Continue** (`.continuerc.json`):
+- Update `customInstructions` field, preserving existing content
+- See [references/format-continue.md](references/format-continue.md)
+
+#### Route B: Update Existing Skill
+
+When adding to an existing skill:
+
+1. Read the skill file: `skills/[name]/SKILL.md`
+2. Find appropriate section or create new one
+3. Append learning, maintaining the skill's existing structure
+4. If skill has references, consider adding to reference file instead
+
+**Skill update format:**
+```markdown
+## [New Section or append to existing]
+
+[Learning content formatted as guidance or workflow step]
+```
+
+#### Route C: Create New Skill
+
+Create in `skills/[name]/SKILL.md` with this template:
+
+```markdown
+---
+name: [learning-topic]
+description: [What this handles and when to use it - triggers belong here, not in body]
+---
+
+# [Learning Topic]
+
+[Learning content structured as workflow]
+
+## Process
+
+### 1. [First Step]
+[Details]
+```
+
+### 6. Summarize
+
+List:
+- Config files modified (with full paths)
+- Sections updated in each file
+- Any skills created
+
+## Examples
+
+| Situation | Learning |
+|-----------|----------|
+| "e2e tests failed because API wasn't running" | Add prerequisite to selected config(s) |
+| "Parse SDK doesn't work with Vite out of the box" | Document workaround in selected config(s) |
+| "Build failed because NODE_ENV wasn't set" | Add required env var to selected config(s) |
+| "Every component needs tests, lint, build..." | Create `add-component` skill |
+| "User asked to update README but config already requires it" | Flag instruction violation — fix wording or prominence, not add new rule |
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| No configs detected | Guide user to initialize one first, exit early |
+| Multiple configs found | Prompt user to select which to update |
+| Malformed config file | Warn and skip that file |
+| Duplicate content exists | Check before adding, warn if similar learning exists |
+| Config file already oversized | Offer refactoring before adding (Step 4) |
+| Learning matches multiple skills | Present options, let user choose which skill to update |
+| Skill file also oversized | Suggest creating sub-skills or reference files |
+| No existing skills found | Skip skill matching, proceed with config or new skill |
+
+## Guidelines
+
+- **Be minimal**: Only add what genuinely helps future sessions
+- **Avoid duplication**: Check for existing similar content before adding
+- **Prefer specificity**: "Run `npm run dev` before e2e tests" beats "ensure services are running"
+- **Focus on non-obvious**: Skip things Claude would naturally do; capture what surprised you

--- a/.agents/skills/learn/references/assistant-configs.md
+++ b/.agents/skills/learn/references/assistant-configs.md
@@ -1,0 +1,41 @@
+# Assistant Configuration Reference
+
+## Format Compatibility
+
+| Format | Assistants | Notes |
+|--------|-----------|-------|
+| Markdown | Claude, Gemini, AGENTS.md, Copilot, Windsurf, Cursor (legacy) | Most universal |
+| MDC | Cursor (modern) | Markdown with YAML frontmatter |
+| JSON | Continue | Requires `customInstructions` key |
+
+## Markdown Config Structure
+
+For markdown-based configs (CLAUDE.md, GEMINI.md, AGENTS.md, Copilot, Windsurf), use standard markdown sections:
+
+```markdown
+# Project Instructions
+
+## Conventions
+- Convention 1
+- Convention 2
+
+## Prerequisites
+- Required setup step
+
+## Environment
+- Required env vars
+```
+
+## Initialization Commands
+
+When no config exists, guide users to their assistant's init process:
+
+| Assistant | How to Initialize |
+|-----------|------------------|
+| Claude Code | `claude /init` |
+| Cursor | Create `.cursorrules` or use Settings > Rules |
+| GitHub Copilot | Create `.github/copilot-instructions.md` manually |
+| Windsurf | Create `.windsurf/rules/rules.md` manually |
+| Continue | Create `.continuerc.json` with `{"customInstructions": ""}` |
+| Gemini | Create `GEMINI.md` manually |
+| Universal | Create `AGENTS.md` manually |

--- a/.agents/skills/learn/references/format-continue.md
+++ b/.agents/skills/learn/references/format-continue.md
@@ -1,0 +1,59 @@
+# Continue Configuration Format
+
+Continue uses JSON format for project-level configuration.
+
+## File Location
+
+Project-level config: `.continuerc.json` in the project root.
+
+## JSON Structure
+
+```json
+{
+  "customInstructions": "Your project-specific instructions here.\n\nMultiple paragraphs separated by newlines.",
+  "models": [],
+  "tabAutocompleteModel": {}
+}
+```
+
+## Adding Learnings
+
+The `customInstructions` field is a single string. To add learnings:
+
+1. Read existing `.continuerc.json`
+2. Parse JSON
+3. Append new content to `customInstructions` (preserve existing)
+4. Write back with proper formatting
+
+### Example Update
+
+**Before:**
+```json
+{
+  "customInstructions": "Use TypeScript strict mode."
+}
+```
+
+**After adding learning:**
+```json
+{
+  "customInstructions": "Use TypeScript strict mode.\n\nAlways run tests before committing: npm test"
+}
+```
+
+## Creating New Config
+
+If `.continuerc.json` doesn't exist:
+
+```json
+{
+  "customInstructions": ""
+}
+```
+
+## Important Notes
+
+- Use `\n` for newlines in JSON strings
+- Escape quotes with `\"`
+- The file must be valid JSON
+- Project-level `.continuerc.json` takes precedence over user-level config at `~/.continue/config.yaml`

--- a/.agents/skills/learn/references/format-cursor-mdc.md
+++ b/.agents/skills/learn/references/format-cursor-mdc.md
@@ -1,0 +1,74 @@
+# Cursor MDC Format
+
+Cursor's modern rules use MDC (Markdown Components) format with YAML frontmatter.
+
+## File Location
+
+Rules are stored in `.cursor/rules/` directory with `.mdc` extension:
+
+```
+.cursor/
+  rules/
+    project-conventions.mdc
+    testing-patterns.mdc
+    api-guidelines.mdc
+```
+
+## MDC Structure
+
+```markdown
+---
+description: Brief description of when this rule applies
+globs: ["**/*.ts", "**/*.tsx"]
+alwaysApply: false
+---
+
+# Rule Title
+
+Rule content in markdown...
+```
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | Yes | When/why this rule applies |
+| `globs` | No | File patterns to match (e.g., `["*.ts"]`) |
+| `alwaysApply` | No | Always include in context (default: false) |
+
+## Adding Learnings
+
+**Option 1: Create new rule file** (recommended for distinct topics)
+
+Create a new `.mdc` file for each learning category:
+- `.cursor/rules/api-patterns.mdc`
+- `.cursor/rules/testing-conventions.mdc`
+
+**Option 2: Append to existing file**
+
+Find the most relevant existing `.mdc` file and append a new section.
+
+## Example
+
+```markdown
+---
+description: API error handling patterns for this project
+globs: ["src/api/**/*.ts", "src/services/**/*.ts"]
+---
+
+# API Error Handling
+
+Always wrap API calls in try-catch and use the custom ApiError class:
+
+\`\`\`typescript
+try {
+  const result = await apiClient.fetch(endpoint);
+} catch (error) {
+  throw new ApiError(error.message, error.status);
+}
+\`\`\`
+```
+
+## Legacy Format (.cursorrules)
+
+The legacy `.cursorrules` file in the project root is plain markdown without frontmatter. Treat it like CLAUDE.md - find the appropriate section and append content.

--- a/.agents/skills/learn/references/options.md
+++ b/.agents/skills/learn/references/options.md
@@ -1,0 +1,30 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, supported assistants, routing logic, and process steps). Then present two questions using `AskUserQuestion`. After the user selects options, store their choices and apply them during the workflow.
+
+## Question 1: Destination
+
+Use `multiSelect: false`. These options are mutually exclusive.
+
+| Option | Description |
+|--------|-------------|
+| Auto-route (default) | Use the routing decision tree to choose skills or config files |
+| Skills only | Only create or update skills, don't modify config files |
+| Config only | Only update config files, don't create new skills |
+
+## Question 2: Additional options
+
+Use `multiSelect: true`. These can be combined.
+
+| Option | Description |
+|--------|-------------|
+| Dry run | Show what would be learned without writing any files |
+| All assistants | Write to every detected config file without prompting |
+
+## How to Apply
+
+When options are selected, apply them by adjusting the workflow:
+- **Skills only**: In the routing step (Step 3), always route to skill creation/update (Routes B and C). Skip Route A (config file updates).
+- **Config only**: In the routing step (Step 3), always route to config file updates (Route A). Skip Routes B and C (skill creation/update).
+- **Dry run**: Run the full analysis and categorization, display the proposed changes, then stop without writing any files.
+- **All assistants**: Skip the "prompt user to select which to update" step when multiple configs are found. Write to all detected config files.

--- a/.agents/skills/learn/references/refactoring.md
+++ b/.agents/skills/learn/references/refactoring.md
@@ -1,0 +1,144 @@
+# Config File Refactoring
+
+## Contents
+
+- [Philosophy](#philosophy)
+- [What Belongs Where](#what-belongs-where)
+- [Refactoring Strategies](#refactoring-strategies)
+- [Measuring Content Value](#measuring-content-value)
+- [Quick Reference](#quick-reference)
+- [Guided Refactoring Process](#guided-refactoring-process)
+- [Extraction Template](#extraction-template)
+
+## Philosophy
+
+Config files (CLAUDE.md, etc.) should contain:
+- Quick reference information needed in every session
+- Project-wide conventions and patterns
+- Critical prerequisites and gotchas
+
+Skills should contain:
+- Multi-step workflows
+- Situation-specific knowledge (applies only in certain contexts)
+- Detailed procedures that would clutter the main config
+
+## What Belongs Where
+
+### Keep in Config Files
+
+- Project tech stack overview
+- Build/test/lint commands
+- Required environment variables (names, not values)
+- Naming conventions
+- File structure overview
+- Critical "always do" / "never do" rules
+- Small, universal learnings (<3 lines)
+
+### Move to Skills
+
+- Step-by-step procedures (>5 steps)
+- Conditional workflows (if X then Y)
+- Detailed debugging guides
+- Integration-specific patterns
+- Infrequently needed reference material
+- Large learnings (>30 lines)
+- Situation-specific knowledge
+
+## Refactoring Strategies
+
+When a config file exceeds the threshold:
+
+### Strategy 1: Extract Workflow Skills
+
+Identify multi-step processes in the config and convert to skills:
+- "When adding a new component..." → `add-component` skill
+- "To debug production issues..." → `debug-production` skill
+- "For database migrations..." → `database-migration` skill
+
+### Strategy 2: Extract Domain Skills
+
+Group related learnings by domain:
+- All testing guidance → `testing-patterns` skill
+- All API patterns → `api-conventions` skill
+- All deployment steps → `deployment` skill
+
+### Strategy 3: Create Reference Files
+
+For skills with dense reference material:
+- Move tables and lists to `references/` subdirectory
+- Keep main SKILL.md focused on workflow
+- Link to references: `See [references/details.md](references/details.md)`
+
+## Measuring Content Value
+
+When evaluating what to keep vs. extract:
+
+| Keep (High Value) | Extract (Lower Frequency) |
+|-------------------|--------------------------|
+| Used every session | Used occasionally |
+| Prevents common errors | Handles edge cases |
+| Universal to project | Specific to subsystem |
+| Quick reference | Detailed procedure |
+| < 5 lines | > 10 lines |
+
+## Quick Reference
+
+| Condition | Action |
+|-----------|--------|
+| Multi-step workflow (>5 steps) | Create new skill |
+| Existing skill covers topic | Update that skill |
+| Config file exceeds threshold | Refactor first OR create skill |
+| Situation-specific learning | Create skill |
+| Learning >30 lines | Prefer skill |
+| Learning <3 lines | Prefer config |
+| Small, universal learning | Add to config |
+
+## Guided Refactoring Process
+
+When a user chooses to extract existing content before adding new learnings:
+
+### 1. Analyze Existing Content
+
+Identify extractable sections:
+
+```
+Analyzing [filename]...
+
+Found extractable sections:
+- Lines 45-120: Testing workflow (75 lines) → Suggest: `testing-workflow` skill
+- Lines 200-280: API patterns (80 lines) → Suggest: `api-patterns` skill
+- Lines 300-350: Deployment steps (50 lines) → Suggest: `deployment` skill
+
+Extracting these would reduce file to ~295 lines.
+```
+
+### 2. Confirm Extraction Targets
+
+Ask user which sections to extract.
+
+### 3. Create Skills
+
+For each confirmed extraction, create `skills/[name]/SKILL.md` with extracted content and add reference to config file: `See [skill-name] skill for [topic]`
+
+### 4. Remove Extracted Content
+
+Delete moved sections from config.
+
+### 5. Add New Learning
+
+Now add the original learning.
+
+## Extraction Template
+
+When creating skills from extracted content:
+
+```markdown
+---
+name: [extracted-topic]
+description: [Brief description derived from section header]
+---
+
+# [Section Title]
+
+[Extracted content, reformatted as workflow if applicable]
+```

--- a/.agents/skills/ship-it/SKILL.md
+++ b/.agents/skills/ship-it/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: ship-it
+description: >-
+  Create branch, commit, push, and open a pull request.
+  Use when: user says "ship it", "ship this", "create a PR", "open a PR",
+  "push and PR", or wants to go from uncommitted changes to an open pull request.
+license: MIT
+compatibility: Requires git and GitHub CLI (gh) with authentication
+metadata:
+  author: Gregory Murray
+  repository: github.com/whatifwedigdeeper/agent-skills
+  version: "0.3"
+---
+
+# Ship: Branch, Commit, Push & PR
+
+## Arguments
+
+Optional text to derive branch name, commit message, or PR title (e.g. `fix login timeout`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
+
+## Process
+
+### 1. Preflight Checks
+
+```bash
+git status
+git branch --show-current
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+# Fallback if origin/HEAD is unset
+if [ -z "$DEFAULT_BRANCH" ]; then
+  DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //')
+fi
+git diff --stat
+git diff --stat --cached
+gh auth status
+```
+
+Determine:
+- What is the default branch? (detect from remote ref, do not assume `main`)
+- Are there changes to commit? (If no staged or unstaged changes, abort with message)
+- Are we on the default branch? (If so, need to create a branch)
+- Are we already on a feature branch?
+- Is `gh` CLI installed and authenticated? (If not, abort: "Install and authenticate the GitHub CLI: https://cli.github.com")
+- Are we in detached HEAD state? (If so, create a branch before proceeding)
+
+### 2. Create Branch (if needed)
+
+Skip this step if already on a feature branch — use the current branch.
+
+If on the default branch or in detached HEAD, create and switch to a new branch:
+
+```bash
+git checkout -b <branch-name>
+```
+
+**Branch naming:**
+- If user provided `$ARGUMENTS`, derive branch name from it (kebab-case, e.g. `fix/handle-null-response`)
+- Otherwise, analyze the changes and generate a descriptive branch name
+- Use prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`, `test/` based on change type
+- If a remote branch with the same name already exists, append a short suffix (e.g. `-2`)
+
+### 3. Stage & Commit
+
+Stage specific files rather than using `git add -A`.
+
+```bash
+git add <file1> <file2> ...
+git diff --cached --name-only
+```
+
+Analyze the diff and generate a conventional commit message. If user provided `$ARGUMENTS` that looks like a commit message, use it directly.
+
+```bash
+git commit -m "type: description"
+```
+
+**Commit fallbacks:**
+- If commit fails due to GPG signing errors (sandbox or keyring issues), retry with `--no-gpg-sign`
+- If heredoc syntax (`$(cat <<'EOF'...)`) fails with "can't create temp file", use multiple `-m` flags instead (e.g. `git commit -m "subject" -m "body"`)
+
+### 4. Push
+
+```bash
+git push -u origin <branch-name>
+```
+
+If push fails due to branch protection or permissions, report the error to the user and stop.
+
+### 5. Create Pull Request
+
+Gather context for the PR description:
+
+```bash
+git log <default-branch>..HEAD --oneline
+git diff <default-branch>..HEAD --stat
+```
+
+Check for an existing PR on this branch:
+
+```bash
+if gh pr view --json url,title,body > /dev/null 2>&1; then
+  gh pr view --json url,title,body
+fi
+```
+
+If a PR already exists:
+1. Compare the current PR title and body against all commits on the branch (`git log <default-branch>..HEAD --oneline`)
+2. If the title or body no longer reflects the full set of changes (e.g. new commits were added), update them with `gh pr edit <number> --title "<new title>" --body "<new body>"`
+3. Report the PR URL and any updates made, then jump to Step 6
+
+Otherwise, create the PR:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- [2-3 bullet points describing the changes]
+
+## Test Plan
+- [ ] [How to test these changes]
+
+---
+Generated with [agent name and link, per agent conventions]
+EOF
+)"
+```
+
+If `gh pr create` fails, report the error to the user (common causes: missing repo permissions, network issues, branch protection rules).
+
+**Title:** If user provided `$ARGUMENTS`, use as PR title. Otherwise generate from the commit(s).
+
+### 6. Report
+
+Output:
+- Branch name
+- Commit hash and message
+- PR URL
+
+## Rules
+
+- Never commit files that look like secrets (.env, credentials, keys, tokens, private keys, build artifacts)
+- If there are merge conflicts with the default branch, warn the user before creating the PR
+- **No sandbox**: This skill uses branch-based isolation. Git and `gh` commands require access to the macOS keyring and credential helpers.

--- a/.agents/skills/ship-it/references/options.md
+++ b/.agents/skills/ship-it/references/options.md
@@ -1,0 +1,31 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, arguments, process steps, and notes). Then present two questions using `AskUserQuestion`. After the user selects options, store their choices and apply them during the workflow.
+
+## Question 1: Workflow scope
+
+Use `multiSelect: false`. These options are mutually exclusive.
+
+| Option | Description |
+|--------|-------------|
+| Full PR (default) | Branch, commit, push, and open a pull request |
+| Commit only | Stage and commit but don't push or create a PR |
+| Push only | Commit and push but don't create a PR |
+
+## Question 2: PR options
+
+Use `multiSelect: true`. These can be combined. Skip this question if the user selected "Commit only" or "Push only" above.
+
+| Option | Description |
+|--------|-------------|
+| Standard PR (Recommended) | No extra options, just create the PR |
+| Draft PR | Create the pull request as a draft |
+| Self-merge | Create the PR and immediately merge it |
+
+## How to Apply
+
+When options are selected, apply them by adjusting the workflow:
+- **Commit only**: Stop after Step 3 (Stage & Commit). Skip push and PR creation.
+- **Push only**: Stop after Step 4 (Push). Skip PR creation.
+- **Draft PR**: Add `--draft` flag to `gh pr create`.
+- **Self-merge**: After creating the PR, run `gh pr merge --merge` and delete the branch.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,86 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Fetch(*)",
+      "Write(*)",
+      "Edit(*)",
+      "Read(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "WebFetch(*)",
+      "Search(*)",
+      "Skill(playwright-cli:*)"
+    ],
+    "deny": [
+      "Read(.env*)",
+      "Write(.env*)",
+      "Edit(.env*)",
+      "Bash(rm -rf /)",
+      "Bash(sudo *)",
+      "Bash(chmod 777 *)"
+    ],
+    "defaultMode": "acceptEdits"
+  },
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude needs your permission\" -sound Glass"
+          }
+        ]
+      },
+      {
+        "matcher": "elicitation_dialog",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude has a question for you\" -sound Glass"
+          }
+        ]
+      },
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude is waiting for your input\" -sound Glass"
+          }
+        ]
+      }
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowUnixSockets": [
+        "/var/run/docker.sock"
+      ],
+      "allowLocalBinding": true
+    },
+    "excludedCommands": [
+      "docker",
+      "gh",
+      "git",
+      "psql",
+      "mysql",
+      "mongosh",
+      "npm",
+      "npx",
+      "playwright",
+      "redis-cli"
+    ]
+  }
+}

--- a/.claude/skills/js-deps
+++ b/.claude/skills/js-deps
@@ -1,0 +1,1 @@
+../../.agents/skills/js-deps

--- a/.claude/skills/learn
+++ b/.claude/skills/learn
@@ -1,0 +1,1 @@
+../../.agents/skills/learn

--- a/.claude/skills/ship-it
+++ b/.claude/skills/ship-it
@@ -1,0 +1,1 @@
+../../.agents/skills/ship-it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Classic algorithm implementations in ES6, based on "Grokking Algorithms" by Manning Press. Some algorithms use tail recursion variants. All code uses ES module syntax (import/export).
+
+## Commands
+
+- **Run all tests:** `npm test`
+- **Run tests in watch mode:** `npm run test.watch`
+- **Run a single test file:** `npx jest src/sort/quickSort.test.js --color`
+- **Lint:** `npm run lint`
+
+## Code Conventions
+
+- ES module syntax (`import`/`export default`) transpiled via Babel
+- Tests use Jest, colocated with source files (e.g., `quickSort.js` / `quickSort.test.js`)
+- Test files use either `.test.js` or `.spec.js` suffix
+- Shared helpers (`head`, `tail`, `isEmpty`) live in `src/util/index.js`
+- Algorithms are organized by category under `src/` (sort, search, graph, recursion, fibonacci, binary-tree, divide-and-conquer)
+- Many algorithms provide both iterative and recursive implementations


### PR DESCRIPTION
## Summary
- Add agent skills for js-deps (dependency management), learn (lesson extraction), and ship-it (branch/commit/push/PR workflow)
- Add Claude Code project settings and skill symlinks
- Add CLAUDE.md with project conventions, commands, and code style guidance

## Test Plan
- [x] Verify skills are correctly linked via `.claude/skills/` symlinks
- [ ] Confirm CLAUDE.md reflects accurate project commands (`npm test`, `npm run lint`, etc.)

---
Generated with [Claude Code](https://claude.ai/code)